### PR TITLE
No stdin for python calls from bash completion functions

### DIFF
--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -46,9 +46,9 @@ __python_argcomplete_run() {
 
 __python_argcomplete_run_inner() {
     if [[ -z "${_ARC_DEBUG-}" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1 </dev/null
     else
-        "$@" 8>&1 9>&2 1>&9 2>&1
+        "$@" 8>&1 9>&2 1>&9 2>&1 </dev/null
     fi
 }
 


### PR DESCRIPTION
Prevents usage of stdin by (python) executables that are called during completion generation. This prevents the completion locking up the entire shell when the python script is broken i.e. it enters an interactive mode (REPL) instead of generating the completions, as expected.

This lockup can be provoked by having a script marked as compatible, but read `stdin` (& wait) for some reason e.g. due to REPL:
```python
#!/usr/bin/python3
# PYTHON_ARGCOMPLETE_OK
from IPython import embed

embed()
```